### PR TITLE
Disables the Anki progress bar before using our progress bar

### DIFF
--- a/awesometts/gui/generator.py
+++ b/awesometts/gui/generator.py
@@ -294,8 +294,6 @@ class BrowserGenerator(ServiceDialog):
 
         self._browser.mw.checkpoint("AwesomeTTS Batch Update")
         self._process['progress'].show()
-        if hasattr(self._browser.mw.progress, "disable"): self._browser.mw.progress.disable(self)
-        self._browser.model.beginReset()
 
         self._accept_next()
 
@@ -493,8 +491,7 @@ class BrowserGenerator(ServiceDialog):
         Display statistics and close out the dialog.
         """
 
-        self._browser.model.endReset()
-        if hasattr(self._browser.mw.progress, "enable"): self._browser.mw.progress.enable()
+        self._browser.model.reset()
 
         proc = self._process
         proc['progress'].accept()

--- a/awesometts/gui/generator.py
+++ b/awesometts/gui/generator.py
@@ -294,6 +294,7 @@ class BrowserGenerator(ServiceDialog):
 
         self._browser.mw.checkpoint("AwesomeTTS Batch Update")
         self._process['progress'].show()
+        if hasattr(self._browser.mw.progress, "disable"): self._browser.mw.progress.disable(self)
         self._browser.model.beginReset()
 
         self._accept_next()
@@ -493,6 +494,7 @@ class BrowserGenerator(ServiceDialog):
         """
 
         self._browser.model.endReset()
+        if hasattr(self._browser.mw.progress, "enable"): self._browser.mw.progress.enable()
 
         proc = self._process
         proc['progress'].accept()

--- a/awesometts/gui/stripper.py
+++ b/awesometts/gui/stripper.py
@@ -191,8 +191,6 @@ class BrowserStripper(Dialog):
         )
 
         self._browser.mw.checkpoint("AwesomeTTS Sound Removal")
-        if hasattr(self._browser.mw.progress, "disable"): self._browser.mw.progress.disable(self)
-        self._browser.model.beginReset()
 
         stat = dict(
             notes=dict(proc=0, upd=0),
@@ -262,8 +260,7 @@ class BrowserStripper(Dialog):
                             'Media" from the Anki "Tools" menu in the main '
                             "window.")
 
-        self._browser.model.endReset()
-        if hasattr(self._browser.mw.progress, "enable"): self._browser.mw.progress.enable()
+        self._browser.model.reset()
         self._addon.config['last_strip_mode'] = mode
         self.setDisabled(False)
         self._notes = None

--- a/awesometts/gui/stripper.py
+++ b/awesometts/gui/stripper.py
@@ -191,6 +191,7 @@ class BrowserStripper(Dialog):
         )
 
         self._browser.mw.checkpoint("AwesomeTTS Sound Removal")
+        if hasattr(self._browser.mw.progress, "disable"): self._browser.mw.progress.disable(self)
         self._browser.model.beginReset()
 
         stat = dict(
@@ -262,6 +263,7 @@ class BrowserStripper(Dialog):
                             "window.")
 
         self._browser.model.endReset()
+        if hasattr(self._browser.mw.progress, "enable"): self._browser.mw.progress.enable()
         self._addon.config['last_strip_mode'] = mode
         self.setDisabled(False)
         self._notes = None


### PR DESCRIPTION
requires https://github.com/ankitects/anki/pull/622 - Allow addons to disable the progress bar when the have their own
fix #21 - Anki 2.1.26 is putting a progress bar on the top of our progress bar

> The problem with this second bar anki puts is that it does not allow to interact it our progress bar and hit the cancel button (and neither we can close the progress bar anki puts up).
> 
> ![image](https://user-images.githubusercontent.com/5332158/81626421-0684c080-93d2-11ea-8e6b-e61497d031ae.png)